### PR TITLE
Bug fixes: two NPEs, bad hint string.

### DIFF
--- a/app/src/main/java/it/alessandromencarini/droidtrailer/GitHubFetcher.java
+++ b/app/src/main/java/it/alessandromencarini/droidtrailer/GitHubFetcher.java
@@ -1,8 +1,6 @@
 package it.alessandromencarini.droidtrailer;
 
 import android.net.Uri;
-import android.util.Log;
-import android.widget.Toast;
 
 import org.eclipse.egit.github.core.RepositoryId;
 import org.eclipse.egit.github.core.User;
@@ -10,7 +8,6 @@ import org.eclipse.egit.github.core.client.GitHubClient;
 import org.eclipse.egit.github.core.service.IssueService;
 import org.eclipse.egit.github.core.service.PullRequestService;
 import org.eclipse.egit.github.core.service.RepositoryService;
-import org.eclipse.egit.github.core.service.UserService;
 import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
@@ -22,7 +19,6 @@ import java.net.HttpURLConnection;
 import java.net.URL;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Map;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -185,12 +181,16 @@ public class GitHubFetcher {
             }
 
             List<String> nextHeader = response.getHeaders().get("Link");
-            String nextUrl = nextHeader.get(0);
-            Pattern pattern = Pattern.compile("<(.*)>; rel=\"next\"");
-            Matcher matcher = pattern.matcher(nextUrl);
+            if (nextHeader != null) {
+                String nextUrl = nextHeader.get(0);
+                Pattern pattern = Pattern.compile("<(.*)>; rel=\"next\"");
+                Matcher matcher = pattern.matcher(nextUrl);
 
-            if (matcher.find()) {
-                url = matcher.group(1);
+                if (matcher.find()) {
+                    url = matcher.group(1);
+                } else {
+                    url = null;
+                }
             } else {
                 url = null;
             }

--- a/app/src/main/java/it/alessandromencarini/droidtrailer/PullRequestListFragment.java
+++ b/app/src/main/java/it/alessandromencarini/droidtrailer/PullRequestListFragment.java
@@ -29,7 +29,6 @@ import android.widget.ArrayAdapter;
 import android.widget.ImageView;
 import android.widget.ListView;
 import android.widget.TextView;
-import android.widget.Toast;
 
 import com.nostra13.universalimageloader.cache.disc.impl.UnlimitedDiscCache;
 import com.nostra13.universalimageloader.core.DisplayImageOptions;
@@ -431,9 +430,11 @@ public class PullRequestListFragment extends ListFragment {
 
             refreshList();
 
-            PullRequest pr = mDataManager.findPullRequest(newComment.getPullRequestId());
-            if (newComment != null && pr.getParticipated() && newComment.getCreatedAt().after(pr.getReadAt()))
-                notifyComments(newComment);
+            if (newComment != null) {
+                PullRequest pr = mDataManager.findPullRequest(newComment.getPullRequestId());
+                if (pr.getParticipated() && newComment.getCreatedAt().after(pr.getReadAt()))
+                    notifyComments(newComment);
+            }
         }
     }
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -7,7 +7,7 @@
     <string name="action_refresh">Refresh</string>
     <string name="action_repositories">Repositories</string>
     <string name="pref_github_key_title">GitHub Key</string>
-    <string name="pref_github_key_hint">On GitHub: Settings | Applications</string>
+    <string name="pref_github_key_hint">On GitHub: Settings | Personal access tokens</string>
     <string name="title_activity_repository">Repositories</string>
     <string name="hello_world">Hello world!</string>
     <string name="no_repositories">There are no repositories available.</string>


### PR DESCRIPTION
### When processing pull requests, don't assume we have any new comments.

If there are no comments, or no new ones have been submitted since the data was last cached, newComment was never set, throwing a `NullPointerException` when `onPostExecute()` tried to call `getPullRequestId()` on it.
### Don't assume github API response headers have "Link" field:

Example curl command:

`curl -i 'https://api.github.com/user/subscriptions?access_token=XXXXXXXXXXX...`

Results in header:

```
HTTP/1.1 200 OK
Server: GitHub.com
Date: Sat, 02 May 2015 20:42:32 GMT
Content-Type: application/json; charset=utf-8
Content-Length: 87759
Status: 200 OK
X-RateLimit-Limit: 5000
X-RateLimit-Remaining: 4968
X-RateLimit-Reset: 1430601576
Cache-Control: private, max-age=60, s-maxage=60
ETag: "XXXXX"
X-OAuth-Scopes: gist, notifications, read:org, read:public_key, repo, user
X-Accepted-OAuth-Scopes:
Vary: Accept, Authorization, Cookie, X-GitHub-OTP
X-GitHub-Media-Type: github.v3
X-XSS-Protection: 1; mode=block
X-Frame-Options: deny
Content-Security-Policy: default-src 'none'
Access-Control-Allow-Credentials: true
Access-Control-Expose-Headers: ETag, Link, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval
Access-Control-Allow-Origin: *
X-GitHub-Request-Id: XXXXX:XXXXX:XXXXX:XXXXX
Strict-Transport-Security: max-age=31536000; includeSubdomains; preload
X-Content-Type-Options: nosniff
Vary: Accept-Encoding
X-Served-By: XXXXX
```
### API keys can be generated by user under "Personal access tokens".

The "Applications" screen in GitHub Preferences shows only GitHub apps that have registered themselves.
![applications](https://cloud.githubusercontent.com/assets/7422100/7442766/db9cef4c-f0d3-11e4-8845-f69e5cee6b68.png)
To generate a token manually, you have to go to "Personal access tokens" settings. Thus, I changed the prompt string under app Settings to reflect this.
![personal](https://cloud.githubusercontent.com/assets/7422100/7442768/ee9fc876-f0d3-11e4-91bd-1aef53775ccb.png)
### Clean up imports.

This was done automatically by AndroidStudio.
